### PR TITLE
[VS2015] add VS2015 compiler support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -65,7 +65,6 @@
 			      'src/unistd'
           ],
           'defines': [
-            'snprintf=_snprintf',
             '_USE_MATH_DEFINES'
           ],
           'configurations': {

--- a/src/color.cc
+++ b/src/color.cc
@@ -10,6 +10,11 @@
 #include <cmath>
 #include <limits>
 
+// Compatibility with Visual Studio versions prior to VS2015
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
+
 /*
  * Parse integer value
  */

--- a/src/init.cc
+++ b/src/init.cc
@@ -17,6 +17,11 @@
 #include "FontFace.h"
 #endif
 
+// Compatibility with Visual Studio versions prior to VS2015
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
+
 extern "C" void
 init (Handle<Object> target) {
   NanScope();


### PR DESCRIPTION
VS2015 defines snprintf already so the manual defining in projects is unnecessary on VS2015+ and will cause compilation failures due to double defining.